### PR TITLE
Add dark mode toggle and external stylesheet for demo

### DIFF
--- a/demo/index-cdn.html
+++ b/demo/index-cdn.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ScrollCue.js Demo</title>
-  <style>
+  <link rel="stylesheet" href="style.css">
+  <!-- <style>
     * {
       box-sizing: border-box;
       margin: 0;
@@ -116,7 +117,7 @@
         max-width: 300px;
       }
     }
-  </style>
+  </style> -->
 </head>
 <body>
 
@@ -130,7 +131,21 @@
 
   <div class="container">
     <p class="scroll-info">👇 Scroll down to see the animations in action! 👇</p>
-    
+    <button id="theme-toggle" style="
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    padding: 0.5rem 1rem;
+    background: white;
+    color: black;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    ">
+    🌙 Dark Mode
+    </button>
     <section class="section">
       <h2 class="section-title">Fade & Slide Animations</h2>
       
@@ -275,5 +290,14 @@
 
   
   <script src="https://unpkg.com/scrollcue.js@latest/scrollcue.all-in-one.min.js"></script>
+  <script>
+    const toggleBtn = document.getElementById('theme-toggle');
+    const body = document.body;
+  
+    toggleBtn.addEventListener('click', () => {
+      body.classList.toggle('dark-mode');
+      toggleBtn.textContent = body.classList.contains('dark-mode') ? '☀️ Light Mode' : '🌙 Dark Mode';
+    });
+  </script>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,119 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ScrollCue.js Demo</title>
-  <style>
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-    
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-      line-height: 1.6;
-      color: #333;
-      background-color: #f8f9fa;
-    }
-    
-    header {
-      background-color: #4a6cf7;
-      color: white;
-      text-align: center;
-      padding: 3rem 1rem;
-      margin-bottom: 2rem;
-    }
-    
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 1rem;
-    }
-    
-    .container {
-      max-width: 1140px;
-      margin: 0 auto;
-      padding: 0 1rem;
-    }
-    
-    .section {
-      padding: 4rem 0;
-      border-bottom: 1px solid #e9ecef;
-    }
-    
-    .section-title {
-      text-align: center;
-      margin-bottom: 2rem;
-      font-size: 1.8rem;
-      color: #4a6cf7;
-    }
-    
-    .animation-container {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 1rem;
-    }
-    
-    .animation-card {
-      background-color: white;
-      border-radius: 8px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-      padding: 1.5rem;
-      text-align: center;
-      width: 240px;
-      margin-bottom: 1.5rem;
-    }
-    
-    .animation-card h3 {
-      margin-bottom: 1rem;
-      color: #4a6cf7;
-    }
-    
-    .card-wrapper {
-      min-height: 200px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
-    
-    .demo-block {
-      width: 100%;
-      height: 120px;
-      background-color: #4a6cf7;
-      color: white;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-weight: bold;
-      border-radius: 4px;
-    }
-    
-    footer {
-      text-align: center;
-      padding: 2rem;
-      color: #6c757d;
-      font-size: 0.9rem;
-    }
-    
-    .scroll-info {
-      text-align: center;
-      padding: 1rem;
-      background-color: #e9ecef;
-      margin: 2rem 0;
-      border-radius: 4px;
-    }
-    
-    @media (max-width: 768px) {
-      .animation-container {
-        flex-direction: column;
-        align-items: center;
-      }
-      
-      .animation-card {
-        width: 100%;
-        max-width: 300px;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
@@ -130,7 +18,21 @@
 
   <div class="container">
     <p class="scroll-info">👇 Scroll down to see the animations in action! 👇</p>
-    
+    <button id="theme-toggle" style="
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    padding: 0.5rem 1rem;
+    background: white;
+    color: black;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    ">
+    🌙 Dark Mode
+    </button>
     <section class="section">
       <h2 class="section-title">Fade & Slide Animations</h2>
       
@@ -274,5 +176,15 @@
   </footer>
 
   <script src="../scrollcue.all-in-one.min.js"></script>
+  <script>
+    const toggleBtn = document.getElementById('theme-toggle');
+    const body = document.body;
+  
+    toggleBtn.addEventListener('click', () => {
+      body.classList.toggle('dark-mode');
+      toggleBtn.textContent = body.classList.contains('dark-mode') ? '☀️ Light Mode' : '🌙 Dark Mode';
+    });
+  </script>
+  
 </body>
 </html>

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,0 +1,200 @@
+:root {
+    --bg-color: linear-gradient(135deg, #ffe4e1, #e0f0ff);
+    --text-color: #2e2e2e;
+    --header-bg: linear-gradient(to right, #ff758c, #4a6cf7);
+    --section-bg: #ffffff;
+    --card-bg: #fef3f3;
+    --card-text: #444;
+    --demo-bg: #4a6cf7;
+    --footer-bg: #fafafa;
+    --footer-border: #dee2e6;
+    --footer-text: #495057;
+    --scroll-info: #ff758c;
+    --shadow: rgba(0, 0, 0, 0.15);
+  }
+  
+  body.dark-mode {
+    --bg-color: linear-gradient(135deg, #1e1e2f, #2a2a3b);
+    --text-color: #f0f0f0;
+    --header-bg: linear-gradient(to right, #33334d, #55556e);
+    --section-bg: #2d2d3f;
+    --card-bg: #3a3a4f;
+    --card-text: #e0e0e0;
+    --demo-bg: #55556e;
+    --footer-bg: #1e1e2f;
+    --footer-border: #444;
+    --footer-text: #ccc;
+    --scroll-info: #4a6cf7;
+    --shadow: rgba(255, 255, 255, 0.1);
+  }
+  
+  /* Reset and Base */
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  body {
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    line-height: 1.6;
+    scroll-behavior: smooth;
+    transition: background 0.3s, color 0.3s;
+  }
+  
+  header {
+    background: var(--header-bg);
+    color: white;
+    text-align: center;
+    padding: 3rem 1rem;
+    box-shadow: 0 8px 16px var(--shadow);
+    border-radius: 0 0 20px 20px;
+    position: relative;
+  }
+  
+  header h1 {
+    font-size: 3.5rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+    margin-bottom: 0.5rem;
+    text-shadow: 1px 1px 5px rgba(0,0,0,0.3);
+  }
+  
+  header p {
+    font-size: 1.2rem;
+    opacity: 0.95;
+  }
+  
+  .container {
+    max-width: 1140px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+  }
+  
+  .scroll-info {
+    text-align: center;
+    font-size: 1.2rem;
+    color: var(--scroll-info);
+    margin: 2rem 0;
+    animation: pulse 1.5s infinite;
+  }
+  
+  @keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.6; transform: scale(1.05); }
+  }
+  
+  .section {
+    padding: 3rem 2rem;
+    background: var(--section-bg);
+    border-radius: 16px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    margin-bottom: 3rem;
+    transition: all 0.3s ease;
+  }
+  
+  .section-title {
+    font-size: 2.5rem;
+    color: var(--scroll-info);
+    margin-bottom: 2rem;
+    text-align: center;
+    border-bottom: 2px solid var(--scroll-info);
+    padding-bottom: 0.5rem;
+  }
+  
+  .animation-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 2rem;
+  }
+  
+  .animation-card {
+    background-color: var(--card-bg);
+    border-radius: 12px;
+    box-shadow: 0 4px 10px var(--shadow);
+    padding: 1.5rem;
+    text-align: center;
+    flex: 1 1 calc(30% - 1rem);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+  
+  .animation-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 10px 20px var(--shadow);
+  }
+  
+  .animation-card h3 {
+    font-size: 1.4rem;
+    margin-bottom: 1rem;
+    color: var(--card-text);
+  }
+  
+  .demo-block {
+    background-color: var(--demo-bg);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 120px;
+    border-radius: 8px;
+    font-weight: bold;
+    font-size: 1rem;
+    box-shadow: 0 4px 10px var(--shadow);
+    transition: transform 0.3s ease;
+  }
+  
+  .demo-block:hover {
+    transform: scale(1.03);
+  }
+  
+  footer {
+    text-align: center;
+    padding: 2.5rem 1rem;
+    color: var(--footer-text);
+    font-size: 1rem;
+    background: var(--footer-bg);
+    border-top: 2px solid var(--footer-border);
+    box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.05);
+  }
+  
+  footer p:first-child {
+    font-weight: bold;
+    font-size: 1.1rem;
+  }
+  
+  .toggle-btn {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: white;
+    color: black;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 25px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background 0.3s;
+  }
+  
+  body.dark-mode .toggle-btn {
+    background: #444;
+    color: white;
+  }
+  
+  @media (max-width: 768px) {
+    .animation-card {
+      flex: 1 1 100%;
+    }
+  
+    header h1 {
+      font-size: 2.5rem;
+    }
+  
+    .section-title {
+      font-size: 2rem;
+    }
+  }
+  


### PR DESCRIPTION
### PR Description:
**Title:** Add dark mode toggle and external stylesheet for demo

**Description:**
This PR adds a dark mode toggle to the demo page and separates the CSS into an external stylesheet for better organization. The main changes include:

- A new dark mode toggle button in the header.
- Support for both dark and light themes using CSS variables.
- An external `styles.css` file to manage all the styles, replacing the previous inline `<style>` tag.
- Adjustments in the HTML structure to accommodate the theme-switching functionality.

This update allows users to switch between the page's light and dark themes, improving their experience based on their preferences.

**Files Changed:**
- `index.html`
- `index-cdn.html`
- `styles.css` (new file to manage styles)

issue solved #1 